### PR TITLE
iRODS integration

### DIFF
--- a/scripts/irods-load.sh
+++ b/scripts/irods-load.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Load the input files for an experiment from iRODS.
+
+# parse command-line arguments
+if [[ $# != 2 ]]; then
+        echo "usage: $0 <remote-dir> <local-dir>"
+        exit -1
+fi
+
+REMOTE_PATH="$1"
+LOCAL_PATH="$2"
+
+# load iRODS module
+shopt -s expand_aliases
+
+module load irods
+
+# connect to iRODS server
+iinit
+
+# download input files
+iget -Pr $REMOTE_PATH $LOCAL_PATH
+
+# exit iRODS
+iexit

--- a/scripts/irods-load.sh
+++ b/scripts/irods-load.sh
@@ -8,7 +8,7 @@ if [[ $# != 2 ]]; then
 fi
 
 REMOTE_PATH="$1"
-LOCAL_PATH="$2"
+LOCAL_PATH="$(realpath $2)"
 
 # load iRODS module
 shopt -s expand_aliases

--- a/scripts/irods-save.sh
+++ b/scripts/irods-save.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Save the output files from a experiment to iRODS.
+
+# parse command-line arguments
+if [[ $# != 2 ]]; then
+        echo "usage: $0 <local-dir> <remote-dir>"
+        exit -1
+fi
+
+LOCAL_PATH="$1"
+REMOTE_PATH="$2"
+
+# load iRODS module
+shopt -s expand_aliases
+
+module load irods
+
+# connect to iRODS server
+iinit
+
+# upload output files
+iput -bPr $LOCAL_PATH $REMOTE_PATH
+
+# exit iRODS
+iexit
+
+# remove all intermediate data and output data from local directory
+# rm -rf $LOCAL_DIR
+# rm -rf [DES]RX* work

--- a/scripts/irods-save.sh
+++ b/scripts/irods-save.sh
@@ -23,7 +23,3 @@ iput -bPr $LOCAL_PATH $REMOTE_PATH
 
 # exit iRODS
 iexit
-
-# remove all intermediate data and output data from local directory
-# rm -rf $LOCAL_DIR
-# rm -rf [DES]RX* work

--- a/scripts/irods-save.sh
+++ b/scripts/irods-save.sh
@@ -7,7 +7,7 @@ if [[ $# != 2 ]]; then
         exit -1
 fi
 
-LOCAL_PATH="$1"
+LOCAL_PATH="$(realpath $1)"
 REMOTE_PATH="$2"
 
 # load iRODS module


### PR DESCRIPTION
My current strategy is to provide iRODS support through external scripts which are run separately from the workflow itself. So far there are three scripts:
- `irods-load.sh`: download input directory from iRODS
- `irods-gather.sh`: gather output files and log files into a single directory
- `irods-save.sh`: upload output directory to iRODS

I think these scripts will make it really easy to setup experiments and push results to iRODS, as long as we use a consistent directory structure on iRODS and in our local workspace.

If you can setup iRODS on Kamiak (which you should be able to with the irods-singularity repo), then you should be able to test these scripts on your end.