### PR TITLE
Fixing race conditions

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -404,14 +404,12 @@ process next_sample {
     success = false
 
     try {
-      // Open the lock file.
-
       attempts = 0
       while (!lock)  {
         if (attempts < 3) {
           try {
             lockfile = new File("${workflow.workDir}/GEMmaker/gemmaker.lock")
-            channel = new RandomAccessFile(lockfile, "rw").getChannel() 
+            channel = new RandomAccessFile(lockfile, "rw").getChannel()
             lock = channel.lock()
           }
           catch (OverlappingFileLockException e) {
@@ -427,7 +425,6 @@ process next_sample {
           throw new Exception("Cannot obtain lock to proceed to next sample after 3 attempts")
         }
       }
-
       sample_file = file("${workflow.workDir}/GEMmaker/process/" + sample_id + '.sample.csv')
       sample_file.moveTo("${workflow.workDir}/GEMmaker/done")
 


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #71

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
I've been having issues on Kamiak with using the current version of GEMmaker for the 26K Ath experiment. I ditched the 10 batch files and combined them into a single file.  It runs fine but crashes from time to time due to race condition when trying to move a file from the `work/GEMmaker/stage` folder into the `work/GEMmaker/process` folder.   

## Testing?
<!--- Please describe in detail how to test these changes. -->
Just try running the example code and make sure all is well.  If you want to really try testing the file locking do the following:
1.  On line 420 change the sleep value to 5000 (5 seconds).
2.  Just after line 427 add an if statement like the following:
   ```
   if (sample_id == "3") {
      sleep 15000
   }
   ```
Then run it.  This test will cause the local file with sample ID "3" to hold the lock.  When the SRA sample file is ready to go it will wait on the lock, and try three times.  The lock should be released after 15 seconds.