### PR TITLE
Altered error strategy to 3 retries max

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -485,7 +485,6 @@ REMOTE_SAMPLES.choice(REMOTE_SAMPLES_ASCP, REMOTE_SAMPLES_PREFETCH) { params.sof
 process ascp {
   tag { sample_id }
   label "aspera"
-  label "retry"
 
   input:
     set val(sample_id), val(run_ids), val(type) from REMOTE_SAMPLES_ASCP
@@ -514,7 +513,6 @@ process ascp {
 process prefetch {
   tag { sample_id }
   label "sratoolkit"
-  label "retry"
 
   input:
     set val(sample_id), val(run_ids), val(type) from REMOTE_SAMPLES_PREFETCH

--- a/nextflow.config.example
+++ b/nextflow.config.example
@@ -121,12 +121,12 @@ k8s {
 
 process {
   container = "systemsgenetics/gemmaker:1.0"
+  errorStrategy = "retry"
+  maxRetries = 3
+
 
   withLabel:rate_limit {
     maxForks = 1
-  }
-  withLabel:retry {
-    errorStrategy = { task.attempt == 2 ? "retry" : "ignore" }
   }
 
   withLabel:aspera {


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #101 & #96

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
This PR fixes two different issues.  
For #101: it adjust the retry policy so that every process gets attempted at most 3 times.  This will fix problems where something odd happens on a node and it's not the fault of the workflow.

For #96: by failing instead of ignoring a failure it prevents GEMmaker from hanging because failed samples don't get removed out of the `work/GEMmaker/process` folder.

This rolls back a fix for issue #39 that the previous "retry" label tried to fix in the event that one SRA failed to download and stopped the whole process. So we should revisit that to find a better way.

## Testing?
<!--- Please describe in detail how to test these changes. -->
The only way to test this is to experience a failure in the wild.  So, I propose just a code review, and perhaps just running the default config to make sure there are no weird problems.
