### PR TITLE
K8s fixes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,7 +22,7 @@ Default:
 
 .. code:: bash
 
-  remote_list_path = "${PWD}/examples/RemoteRunExample/SRA_IDs.txt"
+  remote_list_path = "${baseDir}/examples/RemoteRunExample/SRA_IDs.txt"
 
 Example of ``SRA_IDs.txt`` format:
 
@@ -45,7 +45,7 @@ Default:
 
 .. code:: bash
 
-  local_samples_path = "${PWD}/examples/LocalRunExample/Sample*/*_{1,2}.fastq"
+  local_samples_path = "${baseDir}/examples/LocalRunExample/Sample*/*_{1,2}.fastq"
 
 reference_path
 ==============
@@ -99,7 +99,7 @@ Default:
 
 .. code:: bash
 
-  reference_path = "${PWD}/examples/reference/"
+  reference_path = "${baseDir}/examples/reference/"
 
 reference_prefix
 ================
@@ -124,7 +124,7 @@ Default:
 
 .. code:: bash
 
-  dir = "${PWD}/output"
+  dir = "output"
 
 sample_dir
 ==========

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,11 @@ High-Performance Computing (HPC) cluster
 
 Most HPC clusters do not allow users to run Docker, but provide Singularity instead. You will need to make sure that nextflow and Singularity are installed on your cluster (you may need the help of your HPC administrator). If your HPC environment does not support Singularity, you will need to install the containerized dependencies as Environment Modules. Again, you may need to work with your HPC administrator to install the necessary software and make it available via the module system.
 
+Kubernetes
+==========
+
+GEMmaker can be run on a [Kubernetes](https://kubernetes.io/) cluster with minimal effort. Consult the [kube-runner](https://github.com/SystemsGenetics/kube-runner) project for instructions.
+
 Installing GEMmaker
 ~~~~~~~~~~~~~~~~~~~
 

--- a/nextflow.config.example
+++ b/nextflow.config.example
@@ -21,14 +21,14 @@ params {
   }
 
   input {
-    remote_list_path = "${PWD}/examples/RemoteRunExample/SRA_IDs.txt"
-    local_samples_path = "${PWD}/examples/LocalRunExample/Sample*/*_{1,2}.fastq"
-    reference_path = "${PWD}/examples/reference/"
+    remote_list_path = "${baseDir}/examples/RemoteRunExample/SRA_IDs.txt"
+    local_samples_path = "${baseDir}/examples/LocalRunExample/Sample*/*_{1,2}.fastq"
+    reference_path = "${baseDir}/examples/reference/"
     reference_prefix = "CORG"
   }
 
   output {
-    dir = "${PWD}/output"
+    dir = "output"
     sample_dir = { "${params.output.dir}/${sample_id}" }
     publish_mode = "link"
     publish_sra = true
@@ -100,15 +100,13 @@ docker {
 
 singularity {
   autoMounts = true
-  cacheDir = "${PWD}/work-singularity"
+  cacheDir = "work-singularity"
 }
 
 
 
 k8s {
-	launchDir = "${PWD}"
 	storageClaimName = "deepgtex-prp"
-	storageMountPath = "${PWD}"
 }
 
 


### PR DESCRIPTION
Applies some fixes that allows GEMmaker to be run more easily on a Kubernetes cluster.

## Description

In trying to run this workflow on Kubernetes I discovered a few issues with how some files, mostly the static input files, are handled by GEMmaker. Basically, we used absolute paths for several input files so that they could be accessed from anywhere, but this approach does not work well in the context of Kubernetes. Instead, these files should either be provided via channels or prefixed by the launch directory (`$workflow.launchDir`).

The channels approach works in most cases, but as you can see for the `multiqc` and `create_gem` processes, because they take the output directory as input rather than a list of files, I had to use the prefix approach. This approach seems a bit clunky to me, and in the long run I think it would be better to refactor these processes so that they can consume their inputs via channels if possible.

I did all of this in order to remove the use of `${PWD}` from the config file, because Kubernetes execution does not work correctly with this variable.

## Testing?

Aside from the travis tests, we should make sure that everything still works on Palmetto and Kamiak.