### PR TITLE
Solving issue 99. Checks if reference files exist before runing workflow

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -148,17 +148,6 @@ if (selected_tool == 2)
 
 
 
-
-//file.checkIfExists()
-
-//assert file.exists() : "file not found"
-
-// if (params.input.hisat2.enable == true && !.exists()){
-//   "Error: Plese select a reference file in the `nextflow.config` file"
-// }
-
-
-
 /**
  * Create value channels that can be reused
  */

--- a/main.nf
+++ b/main.nf
@@ -106,11 +106,56 @@ if (params.input.salmon.enable == true) {
 }
 
 if (has_tool == 0) {
-  error "Error: You must select a valid quantification tool in the 'nextflow.config' file"
+  error "Error: You must select one valid quantification tool in the 'nextflow.config' file"
 }
 if (has_tool > 1) {
   error "Error: Please select only one quantification tool in the 'nextflow.config' file"
 }
+// Check to make sure that required reference files exist
+// If Hisat2 was selected:
+if (selected_tool == 0)
+{
+  gtfFile = file(params.input.hisat2.gtf_file)
+  if (gtfFile.isEmpty())
+  {
+    error "Error: GTF reference file for Hisat2 does not exist or is empty!"
+  }
+  hisat2_index_dir = file(params.input.hisat2.index_dir)
+  if(!hisat2_index_dir.isDirectory())
+  {
+    error "Error: hisat2 Index Directory does not exist or is empty!"
+  }
+
+}
+// If Kallisto was selected
+if (selected_tool == 1)
+{
+  kallisto_index_file = file(params.input.kallisto.index_file)
+  if (kallisto_index_file.isEmpty())
+  {
+    error "Error: Kallisto Index File does not exist or is empty!"
+  }
+}
+// If Salmon was selected
+if (selected_tool == 2)
+{
+  salmon_index_dir = file(params.input.salmon.index_dir)
+  if (!salmon_index_dir.isDirectory())
+  {
+    error "Error: Salmon Index Directory does not exist or is empty!"
+  }
+}
+
+
+
+
+//file.checkIfExists()
+
+//assert file.exists() : "file not found"
+
+// if (params.input.hisat2.enable == true && !.exists()){
+//   "Error: Plese select a reference file in the `nextflow.config` file"
+// }
 
 
 
@@ -1016,7 +1061,7 @@ process samtools_sort {
       -o ${sample_id}_vs_${params.input.reference_name}.bam \
       -O bam \
       -T temp \
-      ${sample_id}_vs_${params.input.reference_name}.sam      
+      ${sample_id}_vs_${params.input.reference_name}.sam
     """
 }
 


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #99

## Description
<!--- Describe your changes in detail -->
This adds checks to make sure that reference files/directories exist before attempting to run the workflow. This prevents GEMmaker from hanging when it gets to the alignment step.
<!--- Why is this change required? What problem does it solve? -->
This change is required to make sure that the user understands what is needed before the workflow is run, which will save them time.
<!--- Summarize major changes to the code that you made -->
Added checks that will be run dependent on which alignment tool is selected. Has customized error messages that will be thrown in case a file or directory does not exist.

Example:  
```
Error: Kallisto Index File does not exist or is empty!

 -- Check script 'main.nf' at line: 136 or see '.nextflow.log' file for more details

```
## Testing?
<!--- Please describe in detail how to test these changes. -->
Test by running the sample script with an incorrect reference path (I tested by just deleteing the "C" in Corg"
