### PR TITLE
Fixed issue #108 using links

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -622,13 +622,24 @@ process fastq_merge {
    */
   script:
   """
+  
     if ls *_1.fastq >/dev/null 2>&1; then
-      cat *_1.fastq >> "${sample_id}_1.fastq"
+      # If there is only 1 file, creates a hard link to it rather than copying file
+      if `ls *_1.fastq | wc -l` -eq "1" >/dev/null 2>&1; then
+         ln *_1.fastq ${sample_id}_1.fastq;
+      else
+         cat *_1.fastq >> "${sample_id}_1.fastq"
+      fi
     fi
 
     if ls *_2.fastq >/dev/null 2>&1; then
-      cat *_2.fastq >> "${sample_id}_2.fastq"
+      if `ls *_2.fastq | wc -l` -eq "1" >/dev/null 2>&1; then
+         ln *_2.fastq ${sample_id}_2.fastq;
+      else
+         cat *_2.fastq >> "${sample_id}_2.fastq"
+      fi
     fi
+
   """
 }
 
@@ -1016,7 +1027,7 @@ process samtools_sort {
       -o ${sample_id}_vs_${params.input.reference_name}.bam \
       -O bam \
       -T temp \
-      ${sample_id}_vs_${params.input.reference_name}.sam      
+      ${sample_id}_vs_${params.input.reference_name}.sam
     """
 }
 


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #108 

## Description
<!--- Describe your changes in detail -->
Changed the merge step to check if there is only 1 file. If there is only 1 file, program will not create a link instead of copying.
<!--- Why is this change required? What problem does it solve? -->
This was required to prevent large files from being copied for no reason. Before this update, all files were copied into a new file, even if a simple rename would do. I decided to use links instead of rename so that original files are maintained.
<!--- Summarize major changes to the code that you made -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
Run example, make sure that it does not crash. Can also run with a larger data set that needs to merge files (example does not merge any files, only uses links)
