### PR TITLE
fixed issue 125

### DIFF
--- a/main-e2e.nf
+++ b/main-e2e.nf
@@ -428,9 +428,9 @@ process process_sample {
       -v \
       -p ${task.cpus} \
       -e \
-      -o ${sample_id}_vs_${params.input.reference_name}.gtf \
+      -o ${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf \
       -G ${gtf_file} \
-      -A ${sample_id}_vs_${params.input.reference_name}.ga \
+      -A ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga \
       -l ${sample_id} ${sample_id}_vs_${params.input.reference_name}.bam
 
     # remove BAM file if it will not be published
@@ -441,21 +441,21 @@ process process_sample {
 
     # generate raw counts from hisat2/stringtie
     # Run the prepDE.py script provided by stringtie to get the raw counts.
-    echo "${sample_id}\t./${sample_id}_vs_${params.input.reference_name}.gtf" > gtf_files
+    echo "${sample_id}\t./${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf" > gtf_files
     prepDE.py -i gtf_files -g ${sample_id}_vs_${params.input.reference_name}.raw.pre
 
     # Reformat the raw file to be the same as the TPM/FKPM files.
     cat ${sample_id}_vs_${params.input.reference_name}.raw.pre | \
       grep -v gene_id | \
-      perl -pi -e "s/,/\\t/g" > ${sample_id}_vs_${params.input.reference_name}.raw
+      perl -pi -e "s/,/\\t/g" > ${sample_id}_vs_${params.input.reference_name}.Hisat2.raw
 
     # generate the final FPKM and TPM files
     if [[ ${params.output.publish_fpkm} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$8}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga > ${sample_id}_vs_${params.input.reference_name}.fpkm
+      awk -F"\t" '{if (NR!=1) {print \$1, \$8}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga > ${sample_id}_vs_${params.input.reference_name}.Hisat2.fpkm
     fi
 
     if [[ ${params.output.publish_tpm} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$9}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga > ${sample_id}_vs_${params.input.reference_name}.tpm
+      awk -F"\t" '{if (NR!=1) {print \$1, \$9}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga > ${sample_id}_vs_${params.input.reference_name}.Hisat2.tpm
     fi
 
     if [[ ${params.output.publish_stringtie_gtf_and_ga} == false ]]; then
@@ -469,7 +469,7 @@ process process_sample {
     if [ -e ${sample_id}_2.fastq ]; then
       kallisto quant \
         -i  ${indexes} \
-        -o ${sample_id}_vs_${params.input.reference_name}.ga \
+        -o ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga \
         ${sample_id}_1.fastq \
         ${sample_id}_2.fastq > ${sample_id}.kallisto.log 2>&1
     else
@@ -478,17 +478,17 @@ process process_sample {
         -l 70 \
         -s .0000001 \
         -i ${indexes} \
-        -o ${sample_id}_vs_${params.input.reference_name}.ga \
+        -o ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga \
         ${sample_id}_1.fastq > ${sample_id}.kallisto.log 2>&1
     fi
 
     # generate TPM and raw count files
     if [[ ${params.output.publish_tpm} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.tpm
+      awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.Kallisto.tpm
     fi
 
     if [[ ${params.output.publish_raw} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.raw
+      awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.Kallisto.raw
     fi
 
     if [[ ${params.output.publish_gene_abundance} == false ]]; then
@@ -505,7 +505,7 @@ process process_sample {
         -1 ${sample_id}_1.fastq \
         -2 ${sample_id}_2.fastq \
         -p ${task.cpus} \
-        -o ${sample_id}_vs_${params.input.reference_name}.ga \
+        -o ${sample_id}_vs_${params.input.reference_name}.Salmon.ga \
         --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
     else
       salmon quant \
@@ -513,17 +513,17 @@ process process_sample {
         -l A \
         -r ${sample_id}_1.fastq \
         -p ${task.cpus} \
-        -o ${sample_id}_vs_${params.input.reference_name}.ga \
+        -o ${sample_id}_vs_${params.input.reference_name}.Salmon.ga \
         --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
     fi
 
     # generate final TPM and raw count files
     if [[ ${params.output.publish_tpm} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.tpm
+      awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Salmon.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.Salmon.tpm
     fi
 
     if [[ ${params.output.publish_raw} == true ]]; then
-      awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.raw
+      awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Salmon.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.Salmon.raw
     fi
 
     if [[ ${params.output.publish_gene_abundance} == false ]]; then

--- a/main.nf
+++ b/main.nf
@@ -687,8 +687,8 @@ process kallisto {
     file kallisto_index from KALLISTO_INDEX
 
   output:
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga") into KALLISTO_GA
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga") into KALLISTO_GA_TO_CLEAN
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Kallisto.ga") into KALLISTO_GA
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Kallisto.ga") into KALLISTO_GA_TO_CLEAN
     set val(sample_id), val(1) into CLEAN_MERGED_FASTQ_KALLISTO_SIGNAL
     file "*kallisto.log" into KALLISTO_LOG
 
@@ -697,7 +697,7 @@ process kallisto {
   if [ -e ${sample_id}_2.fastq ]; then
     kallisto quant \
       -i ${kallisto_index} \
-      -o ${sample_id}_vs_${params.input.reference_name}.ga \
+      -o ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga \
       ${sample_id}_1.fastq \
       ${sample_id}_2.fastq > ${sample_id}.kallisto.log 2>&1
   else
@@ -706,7 +706,7 @@ process kallisto {
       -l 70 \
       -s .0000001 \
       -i ${kallisto_index} \
-      -o ${sample_id}_vs_${params.input.reference_name}.ga \
+      -o ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga \
       ${sample_id}_1.fastq > ${sample_id}.kallisto.log 2>&1
   fi
   """
@@ -721,22 +721,22 @@ process kallisto_tpm {
   tag { sample_id }
 
   input:
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga") from KALLISTO_GA
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Kallisto.ga") from KALLISTO_GA
 
   output:
-    file "${sample_id}_vs_${params.input.reference_name}.tpm" optional true into KALLISTO_TPM
-    file "${sample_id}_vs_${params.input.reference_name}.raw" optional true into KALLISTO_RAW
+    file "${sample_id}_vs_${params.input.reference_name}.Kallisto.tpm" optional true into KALLISTO_TPM
+    file "${sample_id}_vs_${params.input.reference_name}.Kallisto.raw" optional true into KALLISTO_RAW
     set val(sample_id), val(1) into CLEAN_KALLISTO_GA_SIGNAL
     val sample_id  into KALLISTO_SAMPLE_COMPLETE_SIGNAL
 
   script:
   """
   if [[ ${params.output.publish_tpm} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.tpm
+    awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.Kallisto.tpm
   fi
 
   if [[ ${params.output.publish_raw} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.raw
+    awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Kallisto.ga/abundance.tsv > ${sample_id}_vs_${params.input.reference_name}.Kallisto.raw
   fi
   """
 }
@@ -757,9 +757,9 @@ process salmon {
     file salmon_index from SALMON_INDEXES
 
   output:
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga") into SALMON_GA
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Salmon.ga") into SALMON_GA
     set val(sample_id), file("*.ga/aux_info/meta_info.json"), file("*.ga/libParams/flenDist.txt") into SALMON_GA_LOG
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga/quant.sf") into SALMON_GA_TO_CLEAN
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Salmon.ga/quant.sf") into SALMON_GA_TO_CLEAN
     set val(sample_id), val(1) into CLEAN_MERGED_FASTQ_SALMON_SIGNAL
 
   script:
@@ -771,7 +771,7 @@ process salmon {
       -1 ${sample_id}_1.fastq \
       -2 ${sample_id}_2.fastq \
       -p ${task.cpus} \
-      -o ${sample_id}_vs_${params.input.reference_name}.ga \
+      -o ${sample_id}_vs_${params.input.reference_name}.Salmon.ga \
       --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
   else
     salmon quant \
@@ -779,7 +779,7 @@ process salmon {
       -l A \
       -r ${sample_id}_1.fastq \
       -p ${task.cpus} \
-      -o ${sample_id}_vs_${params.input.reference_name}.ga \
+      -o ${sample_id}_vs_${params.input.reference_name}.Salmon.ga \
       --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
   fi
   """
@@ -795,22 +795,22 @@ process salmon_tpm {
   tag { sample_id }
 
   input:
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga") from SALMON_GA
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Salmon.ga") from SALMON_GA
 
   output:
-    file "${sample_id}_vs_${params.input.reference_name}.tpm" optional true into SALMON_TPM
-    file "${sample_id}_vs_${params.input.reference_name}.raw" optional true into SALMON_RAW
+    file "${sample_id}_vs_${params.input.reference_name}.Salmon.tpm" optional true into SALMON_TPM
+    file "${sample_id}_vs_${params.input.reference_name}.Salmon.raw" optional true into SALMON_RAW
     set val(sample_id), val(1) into CLEAN_SALMON_GA_SIGNAL
     val sample_id  into SALMON_SAMPLE_COMPLETE_SIGNAL
 
   script:
   """
   if [[ ${params.output.publish_tpm} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.tpm
+    awk -F"\t" '{if (NR!=1) {print \$1, \$4}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Salmon.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.Salmon.tpm
   fi
 
   if [[ ${params.output.publish_raw} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.raw
+    awk -F"\t" '{if (NR!=1) {print \$1, \$5}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Salmon.ga/quant.sf > ${sample_id}_vs_${params.input.reference_name}.Salmon.raw
   fi
   """
 }
@@ -1016,7 +1016,7 @@ process samtools_sort {
       -o ${sample_id}_vs_${params.input.reference_name}.bam \
       -O bam \
       -T temp \
-      ${sample_id}_vs_${params.input.reference_name}.sam      
+      ${sample_id}_vs_${params.input.reference_name}.sam
     """
 }
 
@@ -1068,8 +1068,8 @@ process stringtie {
     file gtf_file from GTF_FILE
 
   output:
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga"), file("${sample_id}_vs_${params.input.reference_name}.gtf") into STRINGTIE_GTF_FOR_FPKM
-    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.*") into STRINGTIE_GTF_FOR_CLEANING
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Hisat2.ga"), file("${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf") into STRINGTIE_GTF_FOR_FPKM
+    set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Hisat2.*") into STRINGTIE_GTF_FOR_CLEANING
     set val(sample_id), val(1) into CLEAN_BAM_SIGNAL
 
   script:
@@ -1078,9 +1078,9 @@ process stringtie {
       -v \
       -p ${task.cpus} \
       -e \
-      -o ${sample_id}_vs_${params.input.reference_name}.gtf \
+      -o ${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf \
       -G ${gtf_file} \
-      -A ${sample_id}_vs_${params.input.reference_name}.ga \
+      -A ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga \
       -l ${sample_id} ${sample_id}_vs_${params.input.reference_name}.bam
     """
 }
@@ -1095,35 +1095,35 @@ process hisat2_fpkm_tpm {
   label "stringtie"
 
   input:
-  set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.ga"), file("${sample_id}_vs_${params.input.reference_name}.gtf") from STRINGTIE_GTF_FOR_FPKM
+  set val(sample_id), file("${sample_id}_vs_${params.input.reference_name}.Hisat2.ga"), file("${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf") from STRINGTIE_GTF_FOR_FPKM
 
 
   output:
-    file "${sample_id}_vs_${params.input.reference_name}.fpkm" optional true into FPKMS
-    file "${sample_id}_vs_${params.input.reference_name}.tpm" optional true into TPM
-    file "${sample_id}_vs_${params.input.reference_name}.raw" optional true into RAW_COUNTS
+    file "${sample_id}_vs_${params.input.reference_name}.Hisat2.fpkm" optional true into FPKMS
+    file "${sample_id}_vs_${params.input.reference_name}.Hisat2.tpm" optional true into TPM
+    file "${sample_id}_vs_${params.input.reference_name}.Hisat2.raw" optional true into RAW_COUNTS
     set val(sample_id), val(1) into CLEAN_STRINGTIE_SIGNAL
     val sample_id into HISAT2_SAMPLE_COMPLETE_SIGNAL
 
   script:
   """
   if [[ ${params.output.publish_fpkm} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$8}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga > ${sample_id}_vs_${params.input.reference_name}.fpkm
+    awk -F"\t" '{if (NR!=1) {print \$1, \$8}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga > ${sample_id}_vs_${params.input.reference_name}.Hisat2.fpkm
   fi
 
   if [[ ${params.output.publish_tpm} == true ]]; then
-    awk -F"\t" '{if (NR!=1) {print \$1, \$9}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.ga > ${sample_id}_vs_${params.input.reference_name}.tpm
+    awk -F"\t" '{if (NR!=1) {print \$1, \$9}}' OFS='\t' ${sample_id}_vs_${params.input.reference_name}.Hisat2.ga > ${sample_id}_vs_${params.input.reference_name}.Hisat2.tpm
   fi
 
   if [[ ${params.output.publish_raw} == true ]]; then
     # Run the prepDE.py script provided by stringtie to get the raw counts.
-    echo "${sample_id}\t./${sample_id}_vs_${params.input.reference_name}.gtf" > gtf_files
+    echo "${sample_id}\t./${sample_id}_vs_${params.input.reference_name}.Hisat2.gtf" > gtf_files
     prepDE.py -i gtf_files -g ${sample_id}_vs_${params.input.reference_name}.raw.pre
 
     # Reformat the raw file to be the same as the TPM/FKPM files.
     cat ${sample_id}_vs_${params.input.reference_name}.raw.pre | \
       grep -v gene_id | \
-      perl -pi -e "s/,/\\t/g" > ${sample_id}_vs_${params.input.reference_name}.raw
+      perl -pi -e "s/,/\\t/g" > ${sample_id}_vs_${params.input.reference_name}.Hisat2.raw
     fi
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,13 +33,13 @@ params {
     // Gene quantification tool inputs. Note, if you are only using one alignment
     // tool, i.e. kallisto, you do not need references for the other alignment tools
     hisat2 {
-      enable = false
+      enable = true
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Hisat2.indexed/"
       index_prefix = "CORG"
       gtf_file = "${baseDir}/examples/reference/CORG.gtf"
     }
     salmon {
-      enable = true
+      enable = false
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Salmon.indexed"
     }
     kallisto {

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
     // Gene quantification tool inputs. Note, if you are only using one alignment
     // tool, i.e. kallisto, you do not need references for the other alignment tools
     hisat2 {
-      enable = true
+      enable = false
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Hisat2.indexed/"
       index_prefix = "CORG"
       gtf_file = "${baseDir}/examples/reference/CORG.gtf"
@@ -43,7 +43,7 @@ params {
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Salmon.indexed"
     }
     kallisto {
-      enable = false
+      enable = true
       index_file = "${baseDir}/examples/reference/CORG.transcripts.Kallisto.indexed"
     }
   }
@@ -54,21 +54,21 @@ params {
     dir = "output"
     sample_dir = { "${params.output.dir}/${sample_id}" }
     publish_mode = "link"
-    publish_sra = false
-    publish_downloaded_fastq = false
+    publish_sra = true
+    publish_downloaded_fastq = true
     publish_tpm = true
-    publish_raw = false
+    publish_raw = true
     multiqc = true
-    create_gem = false
+    create_gem = true
 
     // Salmon and Kallisto specific parameters
-    publish_gene_abundance = false
+    publish_gene_abundance = true
 
     // Hisat2 specific parameters
-    publish_stringtie_gtf_and_ga = false
-    publish_trimmed_fastq = false
-    publish_bam = false
-    publish_sam = false
+    publish_stringtie_gtf_and_ga = true
+    publish_trimmed_fastq = true
+    publish_bam = true
+    publish_sam = true
     publish_fpkm = true
   }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,11 +39,11 @@ params {
       gtf_file = "${baseDir}/examples/reference/CORG.gtf"
     }
     salmon {
-      enable = false
+      enable = true
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Salmon.indexed"
     }
     kallisto {
-      enable = true
+      enable = false
       index_file = "${baseDir}/examples/reference/CORG.transcripts.Kallisto.indexed"
     }
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
     // Gene quantification tool inputs. Note, if you are only using one alignment
     // tool, i.e. kallisto, you do not need references for the other alignment tools
     hisat2 {
-      enable = true
+      enable = false
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Hisat2.indexed/"
       index_prefix = "CORG"
       gtf_file = "${baseDir}/examples/reference/CORG.gtf"
@@ -43,7 +43,7 @@ params {
       index_dir = "${baseDir}/examples/reference/CORG.transcripts.Salmon.indexed"
     }
     kallisto {
-      enable = false
+      enable = true
       index_file = "${baseDir}/examples/reference/CORG.transcripts.Kallisto.indexed"
     }
   }
@@ -54,26 +54,26 @@ params {
     dir = "output"
     sample_dir = { "${params.output.dir}/${sample_id}" }
     publish_mode = "link"
-    publish_sra = true
-    publish_downloaded_fastq = true
+    publish_sra = false
+    publish_downloaded_fastq = false
     publish_tpm = true
     publish_raw = true
     multiqc = true
     create_gem = true
 
     // Salmon and Kallisto specific parameters
-    publish_gene_abundance = true
+    publish_gene_abundance = false
 
     // Hisat2 specific parameters
-    publish_stringtie_gtf_and_ga = true
-    publish_trimmed_fastq = true
-    publish_bam = true
-    publish_sam = true
+    publish_stringtie_gtf_and_ga = false
+    publish_trimmed_fastq = false
+    publish_bam = false
+    publish_sam = false
     publish_fpkm = true
   }
 
   execution {
-    queue_size = 100
+    queue_size = 4
   }
 
   software {


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue # 125

## Description
<!--- Describe your changes in detail -->
GEMmaker now outputs files with the alignment/pseudo alignment tool which they use:
```
1_1_fastqc.html
1_1_fastqc.zip
1_1u_trim.fastq
1_1u_trim_fastqc.html
1_1u_trim_fastqc.zip
1.kallisto.log
1.trim.log
1_vs_CORG.bam
1_vs_CORG.bam.bai
1_vs_CORG.bam.log
1_vs_CORG.Hisat2.fpkm
1_vs_CORG.Hisat2.ga
1_vs_CORG.Hisat2.raw
1_vs_CORG.Hisat2.tpm
1_vs_CORG.Kallisto.ga
1_vs_CORG.Kallisto.raw
1_vs_CORG.Kallisto.tpm
1_vs_CORG.Salmon.ga
1_vs_CORG.Salmon.raw
1_vs_CORG.Salmon.tpm
1_vs_CORG.sam.log
```
Notice that the tool name is only added for processes outputs involved in the actual construction of the ga, gtf, tpm, raw, or fpkm file respectively. 

<!--- Why is this change required? What problem does it solve? -->
This change was required to prevent overwriting processes made by different tools in case a user wishes to use multiple alignment tools.
<!--- Summarize major changes to the code that you made -->

## Testing?
<!--- Please describe in detail how to test these changes. -->
Download, test CORG using all three tools.