### PR TITLE
Added warning errors for missing reference files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -112,7 +112,40 @@ if (has_tool > 1) {
   error "Error: Please select only one quantification tool in the 'nextflow.config' file"
 }
 
+// Check to make sure that required reference files exist
+// If Hisat2 was selected:
+if (selected_tool == 0)
+{
+  gtfFile = file(params.input.hisat2.gtf_file)
+  if (gtfFile.isEmpty())
+  {
+    error "Error: GTF reference file for Hisat2 does not exist or is empty! Please Check that you have the proper references, that they are placed in the reference directory, and they are named properly."
+  }
+  hisat2_index_dir = file(params.input.hisat2.index_dir)
+  if(!hisat2_index_dir.isDirectory())
+  {
+    error "Error: hisat2 Index Directory does not exist or is empty! Please Check that you have the proper references, that they are placed in the reference directory, and they are named properly."
+  }
 
+}
+// If Kallisto was selected
+if (selected_tool == 1)
+{
+  kallisto_index_file = file(params.input.kallisto.index_file)
+  if (kallisto_index_file.isEmpty())
+  {
+    error "Error: Kallisto Index File does not exist or is empty! Please Check that you have the proper references, that they are placed in the reference directory, and they are named properly."
+  }
+}
+// If Salmon was selected
+if (selected_tool == 2)
+{
+  salmon_index_dir = file(params.input.salmon.index_dir)
+  if (!salmon_index_dir.isDirectory())
+  {
+    error "Error: Salmon Index Directory does not exist or is empty! Please Check that you have the proper references, that they are placed in the reference directory, and they are named properly."
+  }
+}
 
 /**
  * Create value channels that can be reused


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #99 

## Description
<!--- Describe your changes in detail -->
Added warning messages that prevent GEMmaker from running if no reference files are present. Warnings example:
```
Error: hisat2 Index Directory does not exist or is empty! Please Check that you have the proper references, that they are placed in the reference directory, and they are named properly.

 -- Check script 'main.nf' at line: 127 or see '.nextflow.log' file for more details
```
<!--- Why is this change required? What problem does it solve? -->
This prevents a user from processing through files until GEMmaker gets to the alignment/pseudo alignment step. GEMmaker would previously hang at that step, which is not good.
<!--- Summarize major changes to the code that you made -->

## Testing?
Clone this branch, run example code. Either modify the name of the reference in the `nextflow.config` or modify the actual name of  the file. This should cause GEMmaker to not know what the file is, and the error above should be thrown.
<!--- Please describe in detail how to test these changes. -->
