### PR TITLE
Issue 138 spf

### DIFF
--- a/main-e2e.nf
+++ b/main-e2e.nf
@@ -225,7 +225,7 @@ process process_sample {
   tag { sample_id }
   label "gemmaker"
   label "multithreaded"
-  errorStrategy { task.attempt < 3 ? "retry" : "ignore" }
+  label "retry_ignore"
   publishDir params.output.sample_dir, mode: params.output.publish_mode
 
   input:

--- a/main.nf
+++ b/main.nf
@@ -567,7 +567,7 @@ process next_sample {
 /**
  * Downloads SRA files from NCBI using the SRA Toolkit.
  */
-process prefetch {
+process download_runs {
   tag { sample_id }
   label "sratoolkit"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -138,7 +138,7 @@ process {
   withLabel:rate_limit {
     maxForks = 1
   }
-  withLabel:retry {
+  withLabel:retry_ignore {
     errorStrategy = { task.attempt < 3 ? "retry" : "ignore" }
   }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -131,6 +131,8 @@ process {
   container = "systemsgenetics/gemmaker:1.0"
   errorStrategy = "retry"
   maxRetries = 3
+  validExitStatus = [0,141]
+
 
   withLabel:rate_limit {
     maxForks = 1


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #138, #118 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
This update removes use of the sratoolkit prefetch command because it's a bit buggy when a failure occurs and replaces it with the `retreive_sra.py` python script that we can debug much easier when something goes wrong.  

In order to remove the other for loops in the workflow there is also the addition of the `sra2fastq.py` script which simply wraps the fastq_dump.

## Testing?
<!--- Please describe in detail how to test these changes. -->
Run the workflow with the example data and make sure nothing breaks.  The only real way to make sure this fixes the problems is to run a large dataset on Kamiak and see if there are any download errors.  I have done that with the Cavendish dataset and I don't get any failed downloads for over 300 samples.
