### PR TITLE
Minor fix to ensure sample names match their original names in GEMs

### DIFF
--- a/bin/create-gem.py
+++ b/bin/create-gem.py
@@ -56,6 +56,9 @@ for result in result_files:
   file_basename = os.path.basename(result)
   sample_name = file_basename.split('.')[0]
 
+  # Remove the _vs_[assembly] from the sample name
+  sample_name = re.sub(r'_vs_.*$', '', sample_name)
+
   # Read in the counts.
   print ("Adding results for sample: "  + sample_name)
   df = pd.read_csv(result, header = None, sep = '\t', names = ["gene", sample_name])


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue # N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
This is a very simple fix to the `create-gem.py` script to remove the "vs_[assembly]" name from the samples in the GEM.  The sample names in the GEM should match the names provided by the user (or the SRX IDs).

## Testing?
<!--- Please describe in detail how to test these changes. -->
Run the example, and then look at the final GEM files.  It should have samples named "2","3","1","SRX218012" rather than  "2_vs_CORG","3_vs_CORG","1_vs_CORG","SRX218012_vs_CORG"
