### PR TITLE
Added workaround to Nextflow baseDir bug on kubernetes

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,6 @@ manifest {
 
 
 
-
 params {
   project {
     name = "CORG RNA-Seq example"
@@ -26,10 +25,6 @@ params {
     // spaces or special characters, only alphanumeric characters and underscores.
     reference_name = "CORG"
 
-    // Gene quantification tool inputs. Note, if you are only using one alignment
-    // tool, i.e. kallisto, you do not need references for the other alignment tools
-
-
     // If you are following the example setup, you do not need to change these
     // parameters.
     reference_dir = "input/references"
@@ -38,6 +33,8 @@ params {
     local_sample_files = "*_{1,2}.fastq"
     skip_list_path = "samples2skip.txt"
 
+    // Gene quantification tool inputs. Note, if you are only using one alignment
+    // tool, i.e. kallisto, you do not need references for the other alignment tools
     hisat2 {
       enable = false
       index_dir = "CORG.genome.Hisat2.indexed"
@@ -53,11 +50,7 @@ params {
     }
   }
 
-
-
-
   output {
-
     // Universal output parameters
     dir = "output"
     sample_dir = { "${params.output.dir}/${sample_id}" }
@@ -141,7 +134,6 @@ process {
   maxRetries = 3
   validExitStatus = [0,141]
 
-
   withLabel:rate_limit {
     maxForks = 1
   }
@@ -202,6 +194,9 @@ profiles {
   }
 
   k8s {
+    params {
+      software.trimmomatic.clip_path = "/workspace/projects/systemsgenetics/GEMmaker/files/fasta_adapter.txt"
+    }
     process {
       executor = "k8s"
       cpus = 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -195,7 +195,8 @@ profiles {
 
   k8s {
     params {
-      software.trimmomatic.clip_path = "/workspace/projects/systemsgenetics/GEMmaker/files/fasta_adapter.txt"
+      input.reference_dir = "input"
+      software.trimmomatic.clip_path = "/workspace/projects/systemsgenetics/gemmaker/files/fasta_adapter.txt"
     }
     process {
       executor = "k8s"


### PR DESCRIPTION
The trimmomatic clip_path parameter uses `${baseDir}` which does not work on kubernetes, refer to the issue I created with Nextflow a while back: https://github.com/nextflow-io/nextflow/issues/1050

This PR adds a little workaround that avoids using `${baseDir}` when using kubernetes. It's contained in the `k8s` profile so it won't affect other environments. I also fixed a couple of weird things I saw with some of the comments but let me know if that was in error and I'll revert them.

Also I've tested this fix on the PRP and it works. :)