### PR TITLE
Removed validExitStatus directive

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -131,7 +131,6 @@ singularity {
 process {
   container = "gemmaker/base:1.1"
   errorStrategy = { task.attempt < 3 ? "retry" : "terminate" }
-  validExitStatus = [0,141]
 
   withLabel:rate_limit {
     maxForks = 1


### PR DESCRIPTION
Issue #184 

This PR simply removes the `validExitStatus` directive as it is now deprecated. I believe we dealt with the underlying issues that motivated the use of this directive by wrapping certain bash commands in python scripts that handle various non-zero exit codes, so I don't think we need to add anything else but I could be wrong.