### PR TITLE
MetaData 

### DIFF
--- a/bin/create_SRA_amx.py
+++ b/bin/create_SRA_amx.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+"""
+A Python script for creating an annotation matrix for NCBI experiments in a GEM.
+
+.. module:: GEMmaker
+    :platform: UNIX, Linux
+    :synopsis: This script recieves a single input argument: a file containing
+       a list of run IDs (numbers with SRR, ERR or DRR prefixes) from NCBI's
+       sequence read archive (SRA). It generates a variety of JSON meta files
+       and outputs a tab-delimited file that maps run IDs to experiment IDs.
+"""
+import argparse
+import codecs
+import json
+import pandas as pd
+import pprint
+import re
+import sys
+import urllib
+import xmltodict
+import pprint
+import pathlib
+import os
+
+
+
+
+
+def map_annotations(experiment, sample, meta_dir, cv_map):
+    """
+    Maps NCBI SRA annotations to controlled vocabularies.
+
+    This function creates both a JSON and tab delimited metadata file that
+    maps metadata from NCBI to known controlled vocabulary terms. The purpose
+    of this is to help ensure uniformity in metadata details between
+    runs of GEMmaker and between different sample sets.
+
+    :param experiment: A dictionary containing the experiment metadata.
+    :param sample: A dictionary containing the sample metadata.
+    :param run: A dictionary containing the run metatdata.
+
+    :return: a dictionary of exerpiment annotations
+    """
+
+    # For case-insenitivity, convert all SRA tags to lower-case
+    tags = [x.lower() for x in cv_map.index.values]
+
+    # Now that we have all the metadata loaded create the non-nested
+    # annotation dictionary
+    annots = {}
+
+    # Build info about the biological sample.
+    # Term: biological sample, sep:00195
+    # Term: data:2091, Accession
+    # Term: schema:title
+    # Term: schema:name
+    annots["sep:00195"] = {}
+    annots["sep:00195"]["data:2091"] = sample.get("@accession", "")
+    annots["sep:00195"]["schema:title"] = sample.get("TITLE", "")
+    annots["sep:00195"]["schema:name"] = sample.get("@alias", "")
+
+    # Add the organism and it's child terms.
+    # Term: organism, obi:0100026
+    # Term: rdfs:label
+    # Term: Scientific Name, NCIT:C43459
+    # Term: NCBI Taxonomy ID, data:1179
+    annots["sep:00195"]["obi:0100026"] = {}
+    annots["sep:00195"]["obi:0100026"]["rdfs:label"] = sample["SAMPLE_NAME"].get("SCIENTIFIC_NAME", "")
+    annots["sep:00195"]["obi:0100026"]["NCIT:C43459"] = sample["SAMPLE_NAME"].get("SCIENTIFIC_NAME", "")
+    annots["sep:00195"]["obi:0100026"]["data:1179"] = sample["SAMPLE_NAME"].get("TAXON_ID", "")
+
+    # Iterate through the sample attributes
+    if "SAMPLE_ATTRIBUTES" in sample and "SAMPLE_ATTRIBUTE" in sample["SAMPLE_ATTRIBUTES"]:
+      attrs = sample["SAMPLE_ATTRIBUTES"]["SAMPLE_ATTRIBUTE"]
+      if not isinstance(attrs, list):
+        attrs = [attrs]
+
+      for attr in attrs:
+        # Skip tags with missing values.
+        if attr["VALUE"].lower() == "missing":
+            continue
+        # Handle the cultivar
+        elif attr["TAG"].lower() == "cultivar":
+            annots["sep:00195"]["obi:0100026"]["GEMmaker:infraspecific_type"] = "cultivar"
+            annots["sep:00195"]["obi:0100026"]["TAXRANK:0000045"] = attr["VALUE"]
+        # Handle tags in the mapping file.
+        elif attr["TAG"].lower() in tags:
+            cvs = cv_map.loc[attr["TAG"].lower()]['CV_IDs'].split(',')
+            code = "annots['%s'] = '%s'" % ("']['".join(cvs), attr["VALUE"])
+            exec(code)
+            print(code)
+        else:
+          sys.stderr.write("Unhandled sample attribute: \"%s\": \"%s\"\n" % (attr["TAG"], attr["VALUE"]))
+
+    return annots
+
+
+
+
+
+
+
+def get_accession_directory(meta_dir, accession):
+    """
+    Given an NCBI SRA accession number, generate a directory path for it.
+
+    This function breaks each accession into 3-character string and
+    creates a directory heirarchy based on the sequence of those sets of
+    characters. If the directory does not exist it will be created.
+
+    :param meta_dir:  The base directory where metadata files will be saved.
+    :param accession: The NCBI SRA accession ID (experiment, run, sample, etc.)
+    """
+    dir = meta_dir + '/SRA_META/' + '/'.join([accession[i:i+3] for i in range(0, len(accession), 3)])
+    pathlib.Path(dir).mkdir(parents=True, exist_ok=True)
+    return dir
+
+
+
+
+
+
+def create_amx(meta_dir, exp_ids, amx, cv_map):
+    """
+    Performs a looking for each run to get it's experiment and prints it.
+
+    Prints the results to STDOUT
+
+    :param mata_dir: The location where metafiles are stored.
+    :param exp_ids: The list of SRA experiment IDs.
+    """
+    for exp_id in exp_ids:
+        run = None
+        experiment = None
+        sample = None
+
+        exp_dir = get_accession_directory(meta_dir, exp_id)
+        exp_path = "%s/%s.ncbi.meta.json" % (exp_dir, exp_id)
+        if os.path.exists(exp_path):
+            with open(exp_path, "r") as exp_file:
+                experiment = json.load(exp_file)
+
+        if experiment is not None:
+            sample_id = experiment['SAMPLE']['@accession']
+            sample_dir = get_accession_directory(meta_dir, sample_id)
+            sample_path = "%s/%s.ncbi.meta.json" % (sample_dir, sample_id)
+            if os.path.exists(sample_path):
+                with open(sample_path, "r") as sample_file:
+                    sample = json.load(sample_file)
+
+        # Convert the data to a JSON array of controlled vocabulary terms
+        if experiment is not None and sample is not None:
+            annots = map_annotations(experiment, sample, meta_dir, cv_map)
+            print(annots)
+
+
+
+
+if __name__ == "__main__":
+
+    # Holds the mapping of SRA runs to experiments.
+    run_to_exp = {}
+
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--emx", help="The GEMmaker produced GEM file.", required=True)
+    parser.add_argument("--amx", help="The file name for the output annotation matrix.", required=True)
+    parser.add_argument("--meta_dir", help="The directory where the SRA_META folder is found", required=True)
+    parser.add_argument("--cv_map", help="The path to the file that contains the mapping of NCBI SRA tags to controlled vocabulary terms. A default file is provided in the 'input/SRAannots2CV.txt' file of GEMmaker.")
+
+    # Get the input arguments.
+    args = parser.parse_args()
+    meta_dir = args.meta_dir
+    amx = args.amx
+
+    # Read in the expression matrix and get the first row. These are the
+    # experiment IDs.
+    emx = pd.read_csv(args.emx, sep="\t", index_col=0, na_values = ['NA'])
+    exp_ids = emx.columns
+
+    # Read in the file that maps NCBI SRA tags to controlled vocabularies.
+    cv_map = pd.read_csv(args.cv_map, sep="\t", comment='#')
+    cv_map.index = cv_map['SRA_Tag']
+
+    # Make the Metadata FAIR
+    create_amx(meta_dir, exp_ids, amx, cv_map)

--- a/bin/fastq_merge.sh
+++ b/bin/fastq_merge.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script determines if there is 1 or 2 files present and concatonates
-# them together
+# them together. It also renames a single sample if the first pair is missing
 
 sample_id="$1"
 
@@ -21,3 +21,10 @@ for file in $files2; do
   cat $file >> "${sample_id}_2.fastq"
 done
 echo "Done with ${sample_id}_2.fastq"
+
+
+# If there is a FASTQ sample with _2 suffix but no _1  then rename
+# to _1 so that count software will work
+if [ -e ${sample_id}_2 ] && [ ! -e ${sample_id}_2 ]; then
+  mv ${sample_id}_2 ${sample_id}_1
+fi

--- a/bin/fastq_merge.sh
+++ b/bin/fastq_merge.sh
@@ -25,6 +25,6 @@ echo "Done with ${sample_id}_2.fastq"
 
 # If there is a FASTQ sample with _2 suffix but no _1  then rename
 # to _1 so that count software will work
-if [ -e ${sample_id}_2 ] && [ ! -e ${sample_id}_2 ]; then
-  mv ${sample_id}_2 ${sample_id}_1
+if [ -e ${sample_id}_2.fastq ] && [ ! -e ${sample_id}_1.fastq ]; then
+  mv ${sample_id}_2.fastq ${sample_id}_1.fastq
 fi

--- a/bin/kallisto.sh
+++ b/bin/kallisto.sh
@@ -4,7 +4,7 @@ sample_id="$1"
 kallisto_index="$2"
 params_input_reference_name="$3"
 
-if [ -e ${sample_id}_2.fastq ]; then
+if [ -e ${sample_id}_1.fastq ] && [ -e ${sample_id}_2.fastq ]; then
   kallisto quant \
     -i ${kallisto_index} \
     -o ${sample_id}_vs_${params_input_reference_name}.Kallisto.ga \

--- a/bin/retrieve_sra.py
+++ b/bin/retrieve_sra.py
@@ -117,8 +117,8 @@ def download_https(run_id, urls):
         r.raw.decode_content = True
         with open("{}.sra".format(run_id), 'wb') as sra_file:
             shutil.copyfileobj(r.raw, sra_file) 
-    except Exception as e: 
-        print(e, file=sys.stderr)
+    except requests.exceptions.RequestException as e:
+        print(str(e), file=sys.stderr)
         ec = 1
     return ec 
 

--- a/bin/retrieve_sra_metadata.py
+++ b/bin/retrieve_sra_metadata.py
@@ -262,7 +262,7 @@ if __name__ == "__main__":
     if args.skip_file and os.path.exists(args.skip_file):
         skip_file = open(args.skip_file, "r")
         skip_ids = [line.strip() for line in skip_file]
-        skip_ids = [skip_id for run_id in skip_ids if skip_id]
+        skip_ids = [skip_id for skip_id in skip_ids if skip_id]
         skip_file.close()
         run_ids = list(set(run_ids).difference(set(skip_ids)))
 
@@ -277,8 +277,8 @@ if __name__ == "__main__":
     missing_runs = find_downloaded_runs(meta_dir, run_ids)
 
     if len(run_ids) - len(missing_runs) > 0:
-        sys.stderr.write("Found %d SRA run file(s) already retreived. Skipping these.\n" % (len(missing_runs)))
-      
+        sys.stderr.write("Found %d SRA run file(s) already retreived. Skipping retreival of these.\n" % (len(run_ids) - len(missing_runs)))
+
     # Download metadata for each SRA run ID that is not already present
     download_runs_meta(missing_runs, meta_dir, args.PAGE_SIZE)
 

--- a/bin/salmon.sh
+++ b/bin/salmon.sh
@@ -4,7 +4,7 @@ sample_id="$1"
 task_cpus="$2"
 params_input_reference_name="$3"
 
-if [ -e ${sample_id}_2.fastq ]; then
+if [ -e ${sample_id}_1.fastq ] && [ -e ${sample_id}_2.fastq ]; then
   salmon quant \
     -i . \
     -l A \
@@ -13,11 +13,19 @@ if [ -e ${sample_id}_2.fastq ]; then
     -p ${task_cpus} \
     -o ${sample_id}_vs_${params_input_reference_name}.Salmon.ga \
     --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
-else
+elif [ -e ${sample_id}_1.fastq ]; then
   salmon quant \
     -i . \
     -l A \
     -r ${sample_id}_1.fastq \
+    -p ${task_cpus} \
+    -o ${sample_id}_vs_${params_input_reference_name}.Salmon.ga \
+    --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1
+else
+  salmon quant \
+    -i . \
+    -l A \
+    -r ${sample_id}_2.fastq \
     -p ${task_cpus} \
     -o ${sample_id}_vs_${params_input_reference_name}.Salmon.ga \
     --minAssignedFrags 1 > ${sample_id}.salmon.log 2>&1

--- a/input/SRAannots2CV.txt
+++ b/input/SRAannots2CV.txt
@@ -1,0 +1,18 @@
+SRA_Tag	CV_IDs	Names
+#
+# BIOLOGICAL SAMPLE
+# This section is for mapping terms associated with the biological sample.
+# The sequence of terms should always start with "sep:00195"
+#
+sample name	sep:00195,schema:name	biological sample,name
+age	sep:00195,NCIT:C25150	biological sample,age
+genotype	sep:00195,NCIT:C16631	biological sample,genotype
+tissue	sep:00195,NCIT:C12801	biological sample,tissue
+dev_stage	sep:00195,NCIT:C43531	biological sample,development stage
+#
+# EXPERIMENT
+# This section is for terms about the experiment
+#
+temp	NCIT:C25206	Temperature
+time	EFO:0000721	time
+treatment	EFO:0000727	treatment

--- a/main-e2e.nf
+++ b/main-e2e.nf
@@ -204,7 +204,7 @@ if ( params.input.hisat2.enabled == false && params.output.publish_raw == false 
  * and maps SRA runs to SRA experiments.
  */
 process retrieve_sra_metadata {
-  publishDir params.output.dir, mode: params.output.publish_mode, pattern: "*.GEMmaker.meta.*", saveAs: { "${it.tokenize(".")[0]}/${it}" }
+  publishDir params.output.dir, mode: params.output.publish_mode, pattern: "missing_runs.txt"
   label "python3"
 
   input:
@@ -212,13 +212,16 @@ process retrieve_sra_metadata {
 
   output:
     stdout REMOTE_SAMPLES_LIST
-    file "*.GEMmaker.meta.*"
+    file "missing_runs.txt" optional
 
   script:
   """
   >&2 echo "#TRACE n_remote_run_ids=`cat ${srr_file} | wc -l`"
 
-  retrieve_sra_metadata.py ${srr_file}
+  retrieve_sra_metadata.py \
+      --run_id_file ${srr_file} \
+      --meta_dir ${workflow.launchDir}/${params.output.dir} \
+      --skip_file ${workflow.launchDir}/${params.input.input_data_dir}/${params.input.skip_list_path}
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -285,7 +285,7 @@ process retrieve_sra_metadata {
 
   script:
     """
-    retrieve_sra_metadata.py --run_id_file ${srr_file} --meta_dir ${workflow.launchDir}/${params.output.dir} --skip_file ${params.input.input_data_dir}/${params.input.skip_list_path}
+    retrieve_sra_metadata.py --run_id_file ${srr_file} --meta_dir ${workflow.launchDir}/${params.output.dir} --skip_file ${workflow.launchDir}/${params.input.input_data_dir}/${params.input.skip_list_path}
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -282,11 +282,10 @@ process retrieve_sra_metadata {
 
   output:
     stdout REMOTE_SAMPLES_LIST
-    file "*.GEMmaker.meta.*"
 
   script:
     """
-    retrieve_sra_metadata.py ${srr_file}
+    retrieve_sra_metadata.py --run_id_file ${srr_file} --meta_dir ${workflow.launchDir}/${params.output.dir}
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -285,7 +285,7 @@ process retrieve_sra_metadata {
 
   script:
     """
-    retrieve_sra_metadata.py --run_id_file ${srr_file} --meta_dir ${workflow.launchDir}/${params.output.dir}
+    retrieve_sra_metadata.py --run_id_file ${srr_file} --meta_dir ${workflow.launchDir}/${params.output.dir} --skip_file ${params.input.input_data_dir}/${params.input.skip_list_path}
     """
 }
 


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #179, #165, #162, and  #172 

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
This PR makes the following fixes:

1.  Changes to the `bin/retrieve_sra_metadata.py` file:
     - The NCBI request for metadata is wrapped in a try-catch statement. This should resolve issue 2 on #179 and print a more readable error message.
     - Also, the script was changed to create a single SRA_META folder where all NCBI metadata is housed.  Previously  this data was only available by digging in the Nextflow `work` directory. 
     -  Previously this script performed two tasks: retrieval of matadata and creation of an annotation matrix (AMX) using controlled vocabularies.  The idea was that AMX file could be used later by KINC. But, the metadata wasn't published (solved by bullet above), and the AMX really should be created after the run completes, so a new `bin/create_SRA_amx.py` script was made and the code that mapped metadata to controlled vocabularies was moved to this script.  This new script, however is not yet used.  I will open a new issue so we don't forget to finish that work.
     -  A new --skip_ids argument was added to the script so that it could ignore the SRAs from tine `input/samples2skip.txt` file.  One of the problems that was identified while fixing this issue was that if a file was listed in the skip file it really only mattered the first time GEMmaker was run.  If a file was added to the skip file after a run (if a sample failed to download) it would not skip it because it was already in the staging folders.
     -  Also, previously if this script failed it would need to start fully over. In the case of the 26K samples from SRA it can take hours to run. If it fails it has to start over.  So now, the script saves the meta data into a folder specified by the --meta_dir parameter. This is a directory outside of the `work` folder that the script can look at to see what metadata already exists. This changes also fixes issue #162 
2. Changes to `main.nf`, `bin/fastq_merge.sh`, `bin/kallisto.sh`, `bin/salmon.sh`
   -  In the process of testing this fix with the Arabiodopsis 26K dataset, some of the samples failed because they are not paired and for some reason the pair is tagged with a `_2` suffix rather than a `_1` suffix.  This caused problems latter on that were pointed out in issue #165. 

## Testing?
<!--- Please describe in detail how to test these changes. -->
This is a hard one to test because these were issues that were discovered as part of the 26K dataset and I failed to record which samples caused problems.  My suggestion would be to review the code to make sure it looks okay, run GEMmaker to make sure nothing obvious broke. If that all looks good we merge, and then as we redo the 26K dataset we make sure none of these issues reappear. If they do we can reopen the issues and repost a new fix.