### PR TITLE
Created 'local' label for local processes

### DIFF
--- a/main-e2e.nf
+++ b/main-e2e.nf
@@ -275,7 +275,7 @@ process process_sample {
   publishDir params.output.sample_dir, mode: params.output.publish_mode
 
   input:
-    set val(sample_id), val(sample_type), val(remote_ids), val(local_files) from ALL_SAMPLES
+    set val(sample_id), val(sample_type), val(remote_run_ids), val(local_fastq_files) from ALL_SAMPLES
     file fasta_adapter from FASTA_ADAPTER
     file indexes from INDEXES
     file gtf_file from GTF_FILE
@@ -315,9 +315,9 @@ process process_sample {
   # for remote samples, prepare FASTQ files from NCBI
   if [[ "${sample_type}" == "remote" ]]; then
     # download SRA files from NCBI
-    echo "#TRACE n_remote_run_ids=${remote_ids.size()}"
+    echo "#TRACE n_remote_run_ids=${remote_run_ids.size()}"
 
-    retrieve_sra.py ${remote_ids.join(' ')}
+    retrieve_sra.py ${remote_run_ids.join(' ')}
 
     # extract FASTQ files from SRA files
     echo "#TRACE sra_bytes=`stat -Lc '%s' *.sra | awk '{sum += \$1} END {print sum}'`"
@@ -341,7 +341,7 @@ process process_sample {
 
   # for local samples, fetch FASTQ files from filesystem
   elif [[ "${sample_type}" == "local" ]]; then
-    cp ${local_files.join(' ')} .
+    cp ${local_fastq_files.join(' ')} .
   fi
 
   # perform fastqc on raw FASTQ files

--- a/nextflow.config
+++ b/nextflow.config
@@ -132,6 +132,11 @@ process {
   container = "gemmaker/base:1.1"
   errorStrategy = { task.attempt < 3 ? "retry" : "terminate" }
 
+  withLabel:local {
+    executor = "local"
+    time = "1h"
+    memory = 1.GB
+  }
   withLabel:gemmaker {
     container = "gemmaker/base:1.1-e2e"
     time = "72h"
@@ -147,7 +152,6 @@ process {
   withLabel:kallisto {
     container = "gemmaker/kallisto:0.45.0-1.1"
     time = "24h"
-    memory = "6 GB"
   }
   withLabel:multiqc {
     container = "gemmaker/multiqc:1.8-1.1"
@@ -298,6 +302,7 @@ profiles {
       queue = "ficklin"
       time = "24h"
       cpus = 1
+      memory = 8.GB
 
       withLabel:multithreaded {
         cpus = 1


### PR DESCRIPTION
This PR creates a 'local' label that is applied to all local processes. I was having issues because these local processes were each allocating 8gb of memory which they didn't need. The local label reduces resources to 1gb and 1h walltime.

I also ended up cleaning the write_stage_files process because it was hard to read.