### PR TITLE
Remove singularity cache dir setting

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -123,7 +123,6 @@ docker {
 
 singularity {
   autoMounts = true
-  cacheDir = "work-singularity"
 }
 
 


### PR DESCRIPTION
## Description
This PR removes the `singularity.cacheDir` setting from `nextflow.config`. During development I had set this up to save singularity images to `work-singularity`, so that singularity images don't get flushed whenever the user cleans out their `work` directory. But now I think that is too opinionated and the setting should be left to it's default for users to override.

By default, singularity images are saved to `work/singularity`. However, Nextflow now offers a better approach (in my opinion), which is to set the singularity cache dir in an environment variable:
```
NXF_SINGULARITY_CACHEDIR=/scratch1/$USER/singularity-cache
```

This way, all of my nextflow runs store singuarity images in a single directory, which prevents duplicate image downloads. So I recommend people do that but the default behavior is fine too.

## Testing?
No testing required, but if you do run it you should see singularity images saved to `work/singularity` instead of `work-singularity`.
