### PR TITLE
Fix for Trimmomatic quality parameter

### DIFF
--- a/bin/trimmomatic.sh
+++ b/bin/trimmomatic.sh
@@ -7,7 +7,7 @@ fasta_adapter="$4"
 params_software_trimmomatic_LEADING="$5"
 params_software_trimmomatic_TRAILING="$6"
 params_software_trimmomatic_SLIDINGWINDOW="$7"
-params_software_trimmomatic_quality=" "
+params_software_trimmomatic_phred_version="$8"
 
 echo $params_software_trimmomatic_LEADING
 echo $params_software_trimmomatic_quality
@@ -36,7 +36,7 @@ if [ -e ${sample_id}_1.fastq ] && [ -e ${sample_id}_2.fastq ]; then
   java -Xmx512m org.usadellab.trimmomatic.Trimmomatic \
     PE \
     -threads ${task_cpus} \
-    ${params_software_trimmomatic_quality} \
+    ${params_software_trimmomatic_phred_version} \
     ${sample_id}_1.fastq \
     ${sample_id}_2.fastq \
     ${sample_id}_1p_trim.fastq \
@@ -58,7 +58,7 @@ else
   java -Xmx512m org.usadellab.trimmomatic.Trimmomatic \
     SE \
     -threads ${task_cpus} \
-    ${params_software_trimmomatic_quality} \
+    ${params_software_trimmomatic_phred_version} \
     ${sample_id}_1.fastq \
     ${sample_id}_1u_trim.fastq \
     ILLUMINACLIP:${fasta_adapter}:2:40:15 \

--- a/bin/trimmomatic.sh
+++ b/bin/trimmomatic.sh
@@ -7,7 +7,6 @@ fasta_adapter="$4"
 params_software_trimmomatic_LEADING="$5"
 params_software_trimmomatic_TRAILING="$6"
 params_software_trimmomatic_SLIDINGWINDOW="$7"
-params_software_trimmomatic_phred_version="$8"
 
 echo $params_software_trimmomatic_LEADING
 echo $params_software_trimmomatic_quality
@@ -36,7 +35,6 @@ if [ -e ${sample_id}_1.fastq ] && [ -e ${sample_id}_2.fastq ]; then
   java -Xmx512m org.usadellab.trimmomatic.Trimmomatic \
     PE \
     -threads ${task_cpus} \
-    ${params_software_trimmomatic_phred_version} \
     ${sample_id}_1.fastq \
     ${sample_id}_2.fastq \
     ${sample_id}_1p_trim.fastq \
@@ -58,7 +56,6 @@ else
   java -Xmx512m org.usadellab.trimmomatic.Trimmomatic \
     SE \
     -threads ${task_cpus} \
-    ${params_software_trimmomatic_phred_version} \
     ${sample_id}_1.fastq \
     ${sample_id}_1u_trim.fastq \
     ILLUMINACLIP:${fasta_adapter}:2:40:15 \

--- a/main.nf
+++ b/main.nf
@@ -45,10 +45,6 @@ hisat2_enable = false
 kallisto_enable = false
 salmon_enable = false
 selected_tool = 0
-phred_version = ''
-if (params.quantification.hisat2.trimmomatic.phred33) {
-    phred_version = '-phred33'
-}
 
 // Print out details per the selected tool.
 if (params.quantification.method.equals('hisat2')) {
@@ -65,7 +61,6 @@ if (params.quantification.method.equals('hisat2')) {
      SLIDINGWINDOW:           ${params.quantification.hisat2.trimmomatic.SLIDINGWINDOW}
      LEADING:                 ${params.quantification.hisat2.trimmomatic.LEADING}
      TRAILING:                ${params.quantification.hisat2.trimmomatic.TRAILING}
-     phred33:                 ${params.quantification.hisat2.trimmomatic.phred33}
   """
 }
 if (params.quantification.method.equals('kallisto')) {
@@ -927,8 +922,7 @@ process trimmomatic {
     ${fasta_adapter} \
     ${params.quantification.hisat2.trimmomatic.LEADING} \
     ${params.quantification.hisat2.trimmomatic.TRAILING} \
-    ${params.quantification.hisat2.trimmomatic.SLIDINGWINDOW} \
-    ${phred_version}
+    ${params.quantification.hisat2.trimmomatic.SLIDINGWINDOW}
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,10 @@ hisat2_enable = false
 kallisto_enable = false
 salmon_enable = false
 selected_tool = 0
+phred_version = ''
+if (params.quantification.hisat2.trimmomatic.phred33) {
+    phred_version = '-phred33'
+}
 
 // Print out details per the selected tool.
 if (params.quantification.method.equals('hisat2')) {
@@ -61,6 +65,7 @@ if (params.quantification.method.equals('hisat2')) {
      SLIDINGWINDOW:           ${params.quantification.hisat2.trimmomatic.SLIDINGWINDOW}
      LEADING:                 ${params.quantification.hisat2.trimmomatic.LEADING}
      TRAILING:                ${params.quantification.hisat2.trimmomatic.TRAILING}
+     phred33:                 ${params.quantification.hisat2.trimmomatic.phred33}
   """
 }
 if (params.quantification.method.equals('kallisto')) {
@@ -923,7 +928,7 @@ process trimmomatic {
     ${params.quantification.hisat2.trimmomatic.LEADING} \
     ${params.quantification.hisat2.trimmomatic.TRAILING} \
     ${params.quantification.hisat2.trimmomatic.SLIDINGWINDOW} \
-    ${params.quantification.hisat2.trimmomatic.quality}
+    ${phred_version}
   """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,20 +26,27 @@ includeConfig "config/manifest.config"
 
 params {
 
+    // This section is for specifying which samples GEMmaker will process.
     samples {
+        // The following is for GEMmaker to automatically download from NCBI SRA.
         ncbi_sra_download {
             remote_sample_list = "./demo/SRA_IDs.txt"
             publish_sra = false
             publish_downloaded_fastq = false
         }
+
+        // Set the GLOB pattern to find samples stored in local directory.
+        // https://en.wikipedia.org/wiki/Glob_(programming)
         local_sample_files = "./demo/*_{1,2}.fastq"
+
+        // Add the IDs of any samples that should be skipped to a file.
         skip_list_path = "./demo/samples2skip.txt"
     }
 
     quantification {
 
         // One of 'kallisto', 'salmon' or 'hisat2'
-        method = 'hisat2'
+        method = 'kallisto'
 
         // Settings for each method. Only adjust settings for the method chosen above.
         kallisto {
@@ -85,7 +92,7 @@ params {
             trimmomatic {
                 clip_path = "${baseDir}/files/fasta_adapter.txt"
                 MINLEN = "0.7"
-                quality = ""
+                phred33 = false
                 SLIDINGWINDOW = "4:15"
                 LEADING = "3"
                 TRAILING = "6"
@@ -104,7 +111,7 @@ params {
 // GENERAL SETTINGS
 // ----------------
 // The following includes default configurations that support reporting,
-// containers, and default settings for execution of processes. If you need to
+// output, and default settings for execution of processes. If you need to
 // override any of the settings in these files pleace do not edit the files
 // themselves, but instead reenter the settings below to override them.
 includeConfig "config/output.config"
@@ -113,7 +120,7 @@ includeConfig "config/process.config"
 
 // PROFILE SETTINGS
 // ----------------
-// You will be executing AnnoTater on one ore more platforms. The following
+// You may be executing GEMmaker on one ore more platforms. The following
 // provides default configruation settings for multiple types of platform
 // profiles.  You will want to override these settings for the platforms on
 // which you are working.  Do not edit the config files listed here but instead

--- a/nextflow.config
+++ b/nextflow.config
@@ -92,7 +92,6 @@ params {
             trimmomatic {
                 clip_path = "${baseDir}/files/fasta_adapter.txt"
                 MINLEN = "0.7"
-                phred33 = false
                 SLIDINGWINDOW = "4:15"
                 LEADING = "3"
                 TRAILING = "6"


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #185

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
The `quality` parameter was not used in the Trimmomatic script was present in the nextflow.config file.  The parameter was meant to enable phred33 conversion. to fix this:
1.   The `quality` parameter was renamed `use_phred33`
2.  The `main.nf` and `trimmomatic.sh` scripts were updated to use this parameter.

## Testing?
<!--- Please describe in detail how to test these changes. -->
Run GEMmaker with the `hisat2` option enabled. Run it twide, once with the `use_phred` to true and once with false. If you then inspect the work folder where trimmomatic was executed, look at the `<sample>.trim.log` file and you'll see at the top of the file contents if the -phred33 flag was used.