### PR TITLE
Minor fix to correct lack of Salmon in MultiQC report

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -934,7 +934,7 @@ process salmon {
 
   output:
     set val(sample_id), file("*.ga") into SALMON_GA
-    set val(sample_id), file("${sample_id}-meta_info.json"), file("${sample_id}-flenDist.txt") into SALMON_GA_LOG
+    set val(sample_id), path("${sample_id}.Salmon.ga", type: 'dir') into SALMON_GA_LOG
     set val(sample_id), file("*.ga/quant.sf") into SALMON_GA_TO_CLEAN
     set val(sample_id), val(1) into CLEAN_MERGED_FASTQ_SALMON_SIGNAL
 


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue # N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
If GEMmaker was run with Salmon then the MultiQC report would have nothing in it for Salmon. this PR fixes that.

## Testing?
<!--- Please describe in detail how to test these changes. -->
Run the following without this PR:
```
#nextflow main.nf -profile test,singularity --pipeline salmon 
```
You'll see no Salmon in the MultiQC report.  Then, pull this PR, rerun and Salmon should now show up in the report.