### PR TITLE
Fixes for the Ath26 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ If you use GEMmaker for your analysis, please cite it using the following:
 
 To cite the nf-core framework for community-curated bioinformatics pipelines:
 >
-> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.
->
-> _Nat Biotechnol._ 2020 Feb 13. doi: [10.5281/zenodo.3620945](http://doi.org/10.5281/zenodo.3620945).
+> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen. The nf-core framework for community-curated bioinformatics pipelines. _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://www.nature.com/articles/s41587-020-0439-x).
 
 ### Tools used by GEMmaker
 

--- a/bin/retrieve_sra.py
+++ b/bin/retrieve_sra.py
@@ -60,6 +60,7 @@ def get_sample_url(run_id):
     # Initialize paths.
     fasp_path = ""
     https_path = ""
+    sra_size = 0
 
     # First try if there is an aspera path.
     p = subprocess.Popen(

--- a/bin/retrieve_sra.py
+++ b/bin/retrieve_sra.py
@@ -21,6 +21,7 @@ import random
 import requests
 import shutil
 import json
+import glob
 
 
 

--- a/main.nf
+++ b/main.nf
@@ -686,6 +686,7 @@ process next_sample {
           }
           catch (OverlappingFileLockException e) {
             // Do nothing, let's try a few more times....
+            println "Failed Lock: " + e.getMessage()
           }
           if (!lock) {
             println "Waiting on lock. After sample, " + sample_id + ", attempt " + attempts + "..."

--- a/main.nf
+++ b/main.nf
@@ -680,7 +680,7 @@ process next_sample {
       // what the optimal wait time should be.
       while (!lock)  {
         // 60 attempts with a sleep of 1 minute == 1 hour.
-        if (attempts < 600) {
+        if (attempts < 3600) {
           try {
             lock = channel.lock()
           }
@@ -689,8 +689,8 @@ process next_sample {
           }
           if (!lock) {
             println "Waiting on lock. After sample, " + sample_id + ", attempt " + attempts + "..."
-            // Sleep for 1 minute
-            sleep 60000
+            // Sleep for 1 second
+            sleep 1000
             attempts = attempts + 1
           }
         }

--- a/main.nf
+++ b/main.nf
@@ -676,21 +676,21 @@ process next_sample {
     try {
       attempts = 0
       channel = new RandomAccessFile("${workflow.workDir}/GEMmaker/gemmaker.lock", "rw").getChannel()
-      // We will try for a release lock for about 10 minutes max. It may take
-      // this long on a slow NFS system.  We will try the lock 3 times before
-      // giving up.
+      // We will try for a release lock for about 1 hour. It's not clear
+      // what the optimal wait time should be.
       while (!lock)  {
-        if (attempts < 3) {
+        // 60 attempts with a sleep of 1 minute == 1 hour.
+        if (attempts < 60) {
           try {
             lock = channel.lock()
           }
           catch (OverlappingFileLockException e) {
             // Do nothing, let's try a few more times....
-            println "Failed Lock: " + e.getMessage()
           }
           if (!lock) {
             println "Waiting on lock. After sample, " + sample_id + ", attempt " + attempts + "..."
-            sleep 1000
+            // Sleep for 1 minute
+            sleep 6000
             attempts = attempts + 1
           }
         }

--- a/main.nf
+++ b/main.nf
@@ -10,10 +10,6 @@
 --------------------------------------------------------------------------------
 */
 
-import java.nio.channels.FileLock
-import java.nio.channels.FileChannel
-import java.nio.channels.OverlappingFileLockException
-
 log.info Headers.nf_core(workflow, params.monochrome_logs)
 
 ////////////////////////////////////////////////////
@@ -419,13 +415,6 @@ ALL_SAMPLES = REMOTE_SAMPLES_FOR_STAGING
 // all samples have completed.
 MULTIQC_BOOTSTRAP = Channel.create()
 CREATE_GEM_BOOTSTRAP = Channel.create()
-
-// Remove any lock file that might be leftover from a previous run
-lockfile = file("${workflow.workDir}/GEMmaker/gemmaker.lock")
-if (lockfile.exists()) {
-    lockfile.delete()
-}
-lockfile = null
 
 // Clean up any files left over from a previous run by moving them
 // back to the stage directory.

--- a/main.nf
+++ b/main.nf
@@ -695,7 +695,7 @@ process next_sample {
           }
         }
         else {
-          throw new Exception("Cannot obtain lock to proceed to next sample after 3 attempts")
+          throw new Exception("Cannot obtain lock to proceed to next sample after " + attempts + " attempts.")
         }
       }
       sample_file = file("${workflow.workDir}/GEMmaker/process/" + sample_id + '.sample.csv')

--- a/main.nf
+++ b/main.nf
@@ -679,8 +679,8 @@ process next_sample {
       // We will try for a release lock for about 1 hour. It's not clear
       // what the optimal wait time should be.
       while (!lock)  {
-        // 60 attempts with a sleep of 1 minute == 1 hour.
-        if (attempts < 3600) {
+        // Sleep for 36000 attempts, that equals about 1 hour.
+        if (attempts < 36000) {
           try {
             lock = channel.lock()
           }
@@ -689,8 +689,8 @@ process next_sample {
           }
           if (!lock) {
             println "Waiting on lock. After sample, " + sample_id + ", attempt " + attempts + "..."
-            // Sleep for 1 second
-            sleep 1000
+            // Sleep for .1 second
+            sleep 100
             attempts = attempts + 1
           }
         }

--- a/main.nf
+++ b/main.nf
@@ -690,7 +690,7 @@ process next_sample {
           if (!lock) {
             println "Waiting on lock. After sample, " + sample_id + ", attempt " + attempts + "..."
             // Sleep for 1 minute
-            sleep 6000
+            sleep 60000
             attempts = attempts + 1
           }
         }

--- a/main.nf
+++ b/main.nf
@@ -680,7 +680,7 @@ process next_sample {
       // what the optimal wait time should be.
       while (!lock)  {
         // 60 attempts with a sleep of 1 minute == 1 hour.
-        if (attempts < 60) {
+        if (attempts < 600) {
           try {
             lock = channel.lock()
           }


### PR DESCRIPTION
<!-- Please provide the following details when submitting your pull request -->

<!-- What issue number does this PR resolve -->
Issue #N/A

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- Summarize major changes to the code that you made -->
This PR represents some tweaks to the workflow to deal with file locking. This is only a problem with huge sample sets.  It turns out that file locking was pointless because you can't lock files between threads of the same Java program (i.e. nextflow).   But, I did find the maxForks directive for a process that only allows it to execute one a time so switching samples should no longer need locking.

## Testing?
There's no way to really test this unless you're running the 26k dataset so I'm going to merge this as is.