### PR TITLE
Palmetto fixes

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -144,6 +144,7 @@ profiles {
     shifter.enabled = false
     charliecloud.enabled = false
     singularity.autoMounts = true
+    singularity.runOptions = "--bind \${NXF_WORK:-$launchDir/work}/GEMmaker"
   }
   podman {
     singularity.enabled = false
@@ -165,6 +166,22 @@ profiles {
     podman.enabled = false
     shifter.enabled = false
     charliecloud.enabled = true
+  }
+  pbs {
+    params {
+      publish_dir_mode = "copy"
+    }
+    process {
+      executor = "pbspro"
+      time = "4h"
+      clusterOptions = '-l select=1:ncpus=2:mem=8gb:interconnect=any'
+      withLabel:multithreaded {
+        clusterOptions = '-l select=1:ncpus=8:mem=8gb:interconnect=any'
+      }
+    }
+    executor {
+      queueSize = 100
+    }
   }
   noclean { includeConfig 'conf/noclean.config' }
   test { includeConfig 'conf/test.config' }


### PR DESCRIPTION
This PR fixes an error we experienced on Palmetto in which retrieve_sra_metadata.py couldn't save meta files to disk. The root cause was that singularity doesn't mount the `work/GEMmaker` directory by default, so I added a line to nextflow.config that should provide a generic solution.

Additionally, I added the pbs profile back to nextflow.config, as we need it to provide some Palmetto-specific settings. I know a lot of things got moved around during the nf-core upgrade, so if there is a preferred way to provide these extra profiles then I'm happy to adjust it, but I would like this profile to be somewhere in the repo. Otherwise we'll just be passing a random code snippet through various slack channels.