### PR TITLE
Upgrade to DSL 2 syntax

### DIFF
--- a/bin/clean_work_dirs.sh
+++ b/bin/clean_work_dirs.sh
@@ -12,13 +12,11 @@
 directory="$1"
 
 for dir in ${directory}; do
-  dir=`echo $dir | perl -p -e 's/[\\[,\\]]//g'`
   if [ -e $dir ]; then
-    echo "Cleaning $dir"
-    file_list=`find $dir -type  f `
-    echo File List to delete: $file_list
-    for file in $file_list; do
-      clean_work_files.sh $file "null"
-    done
+    echo "Cleaning: $dir"
+    files=`find $dir -type  f `
+
+    echo "Files to delete: $files"
+    clean_work_files.sh "$files" "null"
   fi
 done

--- a/bin/clean_work_files.sh
+++ b/bin/clean_work_files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script is meant for cleaning any file in a Nextflow work directory.
-# The $files_list variable is set within the Nextflow process and should
+# The $files variable is set within the Nextflow process and should
 # contain the list of files that need cleaning. This can be done by creating
 # a channel in a process that creates files, and merging that channel with
 # a signal from another process indicating the files are ready for cleaning.
@@ -8,15 +8,14 @@
 # The cleaning process empties the file, converts it to a sparse file so it
 # has an acutal size of zero but appears as the original size, the access
 # and modify times are kept the same.
-files_list="$1"
+files="$1"
 
-for file in ${files_list}; do
-  # Remove cruff added by Nextflow
-  file=`echo $file | perl -p -e 's/[\\[,\\]]//g'`
+for file in ${files}; do
   if [ -e $file ]; then
     # Log some info about the file for debugging purposes
-    echo "cleaning $file"
+    echo "Cleaning: $file"
     stat $file
+
     # Get file info: size, access and modify times
     size=`stat --printf="%s" $file`
     atime=`stat --printf="%X" $file`
@@ -25,6 +24,7 @@ for file in ${files_list}; do
     # Make the file size 0 and set as a sparse file
     > $file
     truncate -s $size $file
+
     # Reset the timestamps on the file
     touch -a -d @$atime $file
     touch -m -d @$mtime $file

--- a/conf/base.config
+++ b/conf/base.config
@@ -19,35 +19,33 @@ process {
   maxRetries = 1
   maxErrors = '-1'
 
-  withLabel:retrieve_sra_metadata {
+  withName:get_software_versions {
+    cache = false
+  }
+  withName:hisat2 {
+    time = 48.h
+  }
+  withName:hisat2_fpkm_tpm {
+    time = 48.h
+  }
+  withName:retrieve_sra_metadata {
     memory = 6.GB
   }
+  withName:samtools_sort {
+    time = 48.h
+  }
+  withName:samtools_index {
+    time = 48.h
+  }
+  withName:stringtie {
+    time = 48.h
+  }
+  withName:trimmomatic {
+    time = 72.h
+  }
+
   withLabel:local {
     executor = "local"
-  }
-  withLabel:fastqc {
-    time = 24.h
-  }
-  withLabel:hisat2 {
-    time = 48.h
-  }
-  withLabel:kallisto {
-    time = 24.h
-  }
-  withLabel:salmon {
-    time = 24.h
-  }
-  withLabel:samtools {
-    time = 48.h
-  }
-  withLabel:sratoolkit {
-    time = 48.h
-  }
-  withLabel:stringtie {
-    time = 48.h
-  }
-  withLabel:trimmomatic {
-    time = 72.h
   }
 
   // Process-specific resource requirements
@@ -69,9 +67,6 @@ process {
   }
   withLabel:process_long {
     time = { check_max( 20.h * task.attempt, 'time' ) }
-  }
-  withName:get_software_versions {
-    cache = false
   }
 
 }

--- a/main.nf
+++ b/main.nf
@@ -344,11 +344,7 @@ workflow {
         ? Channel.fromPath( params.sras )
         : Channel.empty()
 
-    SKIP_SAMPLES_FILE = params.skip_samples
-        ? Channel.fromPath( params.skip_samples )
-        : Channel.fromList( [null] )
-
-    retrieve_sra_metadata(SRR_FILE, SKIP_SAMPLES_FILE)
+    retrieve_sra_metadata(SRR_FILE)
 
     /**
      * Parse remote samples from the SRR2SRX mapping.
@@ -785,20 +781,24 @@ process retrieve_sra_metadata {
 
   input:
     path(srr_file)
-    path(skip_file)
 
   output:
     stdout emit: SRR2SRX
     path("failed_runs.metadata.txt"), emit: FAILED_RUNS
 
   script:
+  skip_arg = ''
+  if (params.skip_samples != '') {
+      skip_file = path(params.skip_samples)
+      skip_arg = "--skip_file ${skip_file}"
+  }
   """
   >&2 echo "#TRACE n_remote_run_ids=`cat ${srr_file} | wc -l`"
 
   retrieve_sra_metadata.py \
       --run_id_file ${srr_file} \
       --meta_dir ${workflow.workDir}/GEMmaker \
-      ${skip_file != null ? "--skip_file ${skip_file}" : ""}
+       ${skip_arg}
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -953,7 +953,7 @@ process kallisto {
     path(kallisto_index)
 
   output:
-    tuple val(sample_id), path("*.ga"), emit: GA_FILES
+    tuple val(sample_id), path("*.ga", type: "dir"), emit: GA_FILES
     tuple val(sample_id), path("*.kallisto.log"), emit: LOGS
     tuple val(sample_id), val(DONE_SENTINEL), emit: DONE_SIGNAL
 
@@ -1014,7 +1014,7 @@ process salmon {
     path(salmon_index)
 
   output:
-    tuple val(sample_id), path("*.ga"), emit: GA_FILES
+    tuple val(sample_id), path("*.ga", type: "dir"), emit: GA_FILES
     tuple val(sample_id), path("*.ga", type: "dir"), emit: LOGS
     tuple val(sample_id), val(DONE_SENTINEL), emit: DONE_SIGNAL
 

--- a/main.nf
+++ b/main.nf
@@ -547,7 +547,7 @@ workflow {
 
     /**
      * The multiqc process should run when all samples have
-     * completed or if on a resume when the bootstrap signal is
+     * completed or on a resume when the bootstrap signal is
      * received.
      */
     if ( params.publish_multiqc_report ) {
@@ -777,7 +777,6 @@ process get_software_versions {
  */
 process retrieve_sra_metadata {
   publishDir params.outdir, mode: params.publish_dir_mode, pattern: "failed_runs.metadata.txt"
-  label "retrieve_sra_metadata"
 
   input:
     path(srr_file)
@@ -837,10 +836,8 @@ process next_sample {
  * Downloads SRA files from NCBI using the SRA Toolkit.
  */
 process download_runs {
-  publishDir params.outdir, mode: params.publish_dir_mode, pattern: '*.failed_runs.download.txt', saveAs: { "Samples/${sample_id}/${it}" }
-
   tag { sample_id }
-  label "download_runs"
+  publishDir params.outdir, mode: params.publish_dir_mode, pattern: '*.failed_runs.download.txt', saveAs: { "Samples/${sample_id}/${it}" }
 
   input:
     tuple val(sample_id), val(run_ids), val(type)
@@ -866,10 +863,9 @@ process download_runs {
  * Extracts FASTQ files from downloaded SRA files.
  */
 process fastq_dump {
+  tag { sample_id }
   publishDir params.outdir, mode: params.publish_dir_mode, pattern: publish_pattern_fastq_dump, saveAs: { "Samples/${sample_id}/${it}" }
   publishDir params.outdir, mode: params.publish_dir_mode, pattern: '*.failed_runs.fastq-dump.txt', saveAs: { "Samples/${sample_id}/${it}" }
-  tag { sample_id }
-  label "fastq_dump"
 
   input:
     tuple val(sample_id), path(sra_files)
@@ -919,9 +915,8 @@ process fastq_merge {
  * Performs fastqc on raw fastq files
  */
 process fastqc_1 {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*_fastqc.*"
   tag { sample_id }
-  label "fastqc"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*_fastqc.*"
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -945,10 +940,8 @@ process fastqc_1 {
  * Performs KALLISTO alignemnt of fastq files
  */
 process kallisto {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_kallisto_ga
   tag { sample_id }
-  label "process_medium"
-  label "kallisto"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_kallisto_ga
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -980,8 +973,8 @@ process kallisto {
  * Generates the final TPM and raw count files for Kallisto
  */
 process kallisto_tpm {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
   tag { sample_id }
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
 
   input:
     tuple val(sample_id), path(ga_file)
@@ -1008,10 +1001,8 @@ process kallisto_tpm {
  * Performs SALMON alignemnt of fastq files
  */
 process salmon {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_salmon_ga
   tag { sample_id }
-  label "process_medium"
-  label "salmon"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_salmon_ga
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -1042,8 +1033,8 @@ process salmon {
  * Generates the final TPM file for Salmon
  */
 process salmon_tpm {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
   tag { sample_id }
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
 
   input:
     tuple val(sample_id), path(ga_file)
@@ -1078,10 +1069,9 @@ process salmon_tpm {
  * "nextflow.config" file
  */
 process trimmomatic {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_trimmomatic
   tag { sample_id }
   label "process_medium"
-  label "trimmomatic"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_trimmomatic
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -1122,9 +1112,8 @@ process trimmomatic {
  * Files are stored to an independent folder
  */
 process fastqc_2 {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*_fastqc.*"
   tag { sample_id }
-  label "fastqc"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*_fastqc.*"
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -1148,10 +1137,9 @@ process fastqc_2 {
  * Performs hisat2 alignment of fastq files to a genome reference
  */
 process hisat2 {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*.log"
   tag { sample_id }
   label "process_medium"
-  label "hisat2"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: "*.log"
 
   input:
     tuple val(sample_id), path(fastq_files)
@@ -1183,9 +1171,8 @@ process hisat2 {
  * Sorts the SAM alignment file and coverts it to binary BAM
  */
 process samtools_sort {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_samtools_sort
   tag { sample_id }
-  label "samtools"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_samtools_sort
 
   input:
     tuple val(sample_id), path(sam_file)
@@ -1213,9 +1200,8 @@ process samtools_sort {
  * Indexes the BAM alignment file
  */
 process samtools_index {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_samtools_index
   tag { sample_id }
-  label "samtools"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_samtools_index
 
   input:
     tuple val(sample_id), path(bam_file)
@@ -1241,10 +1227,9 @@ process samtools_index {
  * Generates expression-level transcript abundance
  */
 process stringtie {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_stringtie_ga_gtf
   tag { sample_id }
   label "process_medium"
-  label "stringtie"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode, pattern: publish_pattern_stringtie_ga_gtf
 
   input:
     tuple val(sample_id), path(bam_file)
@@ -1278,9 +1263,8 @@ process stringtie {
  * Generates the final FPKM / TPM / raw files from Hisat2
  */
 process hisat2_fpkm_tpm {
-  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
   tag { sample_id }
-  label "stringtie"
+  publishDir "${params.outdir}/Samples/${sample_id}", mode: params.publish_dir_mode
 
   input:
     tuple val(sample_id), path(stringtie_files)
@@ -1314,7 +1298,6 @@ process hisat2_fpkm_tpm {
  * Process to generate the multiqc report once everything is completed
  */
 process multiqc {
-  label "multiqc"
   cache false
   publishDir "${params.outdir}/reports", mode: params.publish_dir_mode
 
@@ -1340,7 +1323,6 @@ process multiqc {
  * Creates the GEM file from all the FPKM/TPM outputs
  */
 process create_gem {
-  label "create_gem"
   publishDir "${params.outdir}/GEMs", mode: params.publish_dir_mode
 
   input:
@@ -1376,7 +1358,6 @@ process create_gem {
  * Creates a report of any SRA run IDs that failed and why they failed.
  */
 process failed_run_report {
-  label "reports"
   publishDir "${params.outdir}/reports", mode: params.publish_dir_mode
 
   input:

--- a/main.nf
+++ b/main.nf
@@ -423,7 +423,6 @@ workflow {
         }
         .set { NEXT_SAMPLE }
 
-
     /**
      * Merge local samples with local fastq files.
      */
@@ -435,7 +434,6 @@ workflow {
      * Download, extract, and merge remote samples.
      */
     if ( params.sras ) {
-
         REMOTE_SAMPLES = NEXT_SAMPLE.remote
 
         download_runs(REMOTE_SAMPLES)
@@ -448,8 +446,9 @@ workflow {
         MERGED_FASTQ_FILES = fastq_merge.out.FASTQ_FILES
 
         FAILED_SAMPLES = Channel.empty()
-            .mix(download_runs.out.FAILED_SAMPLES.map { it[0] },
-                 fastq_dump.out.FAILED_SAMPLES.map { it[0] })
+            .mix(
+                download_runs.out.FAILED_SAMPLES.map { it[0] },
+                fastq_dump.out.FAILED_SAMPLES.map { it[0] })
     }
     else {
         REMOTE_SAMPLES = Channel.empty()
@@ -827,9 +826,6 @@ process retrieve_sra_metadata {
   output:
   stdout emit: SRR2SRX
   path("failed_runs.metadata.txt"), emit: FAILED_RUNS
-
-  when:
-  params.sras
 
   script:
   """

--- a/main.nf
+++ b/main.nf
@@ -441,12 +441,12 @@ workflow {
 
         trimmomatic(FASTQ_FILES, FASTA_ADAPTER)
         TRIMMED_FASTQ_FILES = trimmomatic.out.FASTQ_FILES
+        MERGED_FASTQ_DONE = trimmomatic.out.DONE_SIGNAL
 
         fastqc_2(TRIMMED_FASTQ_FILES)
 
         hisat2(TRIMMED_FASTQ_FILES, HISAT2_INDEXES)
         SAM_FILES = hisat2.out.SAM_FILES
-        MERGED_FASTQ_DONE = hisat2.out.DONE_SIGNAL
 
         samtools_sort(SAM_FILES)
         BAM_FILES = samtools_sort.out.BAM_FILES
@@ -627,7 +627,7 @@ workflow {
         CLEAN_SRA_READY = SRA_FILES
             .mix(fastq_dump.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_sra(CLEAN_SRA_READY)
     }
@@ -639,7 +639,7 @@ workflow {
         CLEAN_DOWNLOADED_FASTQ_READY = DOWNLOADED_FASTQ_FILES
             .mix(fastq_merge.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_downloaded_fastq(CLEAN_DOWNLOADED_FASTQ_READY)
     }
@@ -654,7 +654,7 @@ workflow {
                 fastqc_1.out.DONE_SIGNAL,
                 MERGED_FASTQ_DONE)
             .groupTuple(size: 3)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_merged_fastq(CLEAN_MERGED_FASTQ_READY)
     }
@@ -668,7 +668,7 @@ workflow {
                 fastqc_2.out.DONE_SIGNAL,
                 hisat2.out.DONE_SIGNAL)
             .groupTuple(size: 3)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_trimmed_fastq(CLEAN_TRIMMED_FASTQ_READY)
     }
@@ -680,7 +680,7 @@ workflow {
         CLEAN_SAM_READY = SAM_FILES
             .mix(samtools_sort.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_sam(CLEAN_SAM_READY)
     }
@@ -692,7 +692,7 @@ workflow {
         CLEAN_BAM_READY = BAM_FILES
             .mix(stringtie.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_bam(CLEAN_BAM_READY)
     }
@@ -704,7 +704,7 @@ workflow {
         CLEAN_STRINGTIE_READY = STRINGTIE_FILES
             .mix(hisat2_fpkm_tpm.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_stringtie_ga(CLEAN_STRINGTIE_READY)
     }
@@ -728,7 +728,7 @@ workflow {
         CLEAN_SALMON_GA_READY = GA_FILES
             .mix(salmon_tpm.out.DONE_SIGNAL)
             .groupTuple(size: 2)
-            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL}] }
+            .map { [it[0], it[1].flatten().findAll { v -> v != DONE_SENTINEL }] }
 
         clean_salmon_ga(CLEAN_SALMON_GA_READY)
     }
@@ -1090,6 +1090,7 @@ process trimmomatic {
   output:
     tuple val(sample_id), path("*_trim.fastq"), emit: FASTQ_FILES
     tuple val(sample_id), path("*.trim.log"), emit: LOGS
+    tuple val(sample_id), val(DONE_SENTINEL), emit: DONE_SIGNAL
 
   script:
   """

--- a/main.nf
+++ b/main.nf
@@ -293,16 +293,6 @@ publish_pattern_salmon_ga = params.salmon_keep_data
  */
 DONE_SENTINEL = 1
 
-/**
- * Clean up any files left over from a previous run by moving them
- * back to the stage directory.
- */
-existing_files = file('work/GEMmaker/process/*')
-for (existing_file in existing_files) {
-  existing_file.moveTo('work/GEMmaker/stage')
-}
-existing_files = null
-
 workflow {
     get_software_versions()
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -210,7 +210,7 @@ manifest {
   homePage = 'https://github.com/systemsgenetics/gemmaker'
   description = 'GEMmaker is a Nextflow workflow for large-scale gene expression sample processing, expression-level quantification and Gene Expression Matrix (GEM) construction. Results from GEMmaker are useful for differential gene expression (DGE) and gene co-expression network (GCN) analyses. The GEMmaker workflow currently supports Illumina RNA-seq datasets.'
   mainScript = 'main.nf'
-  nextflowVersion = '>=20.04.0'
+  nextflowVersion = '>=21.04.0'
   version = '2.0.0'
 }
 


### PR DESCRIPTION
Nextflow's [DSL 2 syntax](https://nextflow.io/docs/latest/dsl2.html) provides a much better way to write pipeline scripts. The DSL 2 allows you to place all of the channel logic into a single "workflow" block, instead of this logic being scattered throughout the script and within the process blocks. Additionally, DSL 2 allows you to use the same channel multiple times instead of making copies via `into`.

GEMmaker has a lot of this glue logic, which makes it very hard to read, understand, and maintain. As such it should benefit tremendously from DSL 2. I intend to make this migration and then simplify the channel logic as much as I can.

I am submitting this PR now so that anyone who's interested can track my progress and provide input along the way. At this point, I have made the bare minimum changes required to satisfy DSL 2, and the workflow runs correctly... mostly. However, I think the channel logic can be simplified much further, so I will continue to work on it. I'll let you know when it's ready to review for merge.

My running checklist:
- [x] Move all channel logic into workflow block
- [x] Refactor process blocks to adhere to DSL 2 syntax
- [x] Remove features that are deprecated by DSL 2
- [x] Simplify channel logic (DSL 2 provides implicit forking)
- [x] Verify functional correctness

DSL 2 also introduces the ability to have separate module files. While I don't intend to incorporate this feature in this PR, GEMmaker will likely benefit from being reorganized into modules as well, so migrating to DSL 2 is the first step towards that dream.